### PR TITLE
Dynamically generate CommonCrypto module maps

### DIFF
--- a/CatCrypto.xcodeproj/project.pbxproj
+++ b/CatCrypto.xcodeproj/project.pbxproj
@@ -209,13 +209,6 @@
 		C39EDD711FECF95C0081108F /* Verification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Verification.swift; sourceTree = "<group>"; };
 		C39EDD761FECF9D00081108F /* Argon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argon.swift; sourceTree = "<group>"; };
 		C39EDD7B1FECFB0B0081108F /* MessageDigest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDigest.swift; sourceTree = "<group>"; };
-		C3A12E961FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12E981FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12E9A1FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12E9C1FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12E9E1FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12EA01FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		C3A12EA21FE3A3D2007BA5FA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		C3B0F84C1FF6024300FB4DC8 /* SHATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHATests.swift; sourceTree = "<group>"; };
 		C3BDFE011FFE6C3100E060F6 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		C3BDFE031FFE6C9400E060F6 /* SimpleFIPS202.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SimpleFIPS202.h; sourceTree = "<group>"; };
@@ -357,20 +350,6 @@
 			path = Argon2;
 			sourceTree = "<group>";
 		};
-		C358E7921FE2700600A352D0 /* CommonCrypto */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E9B1FE3A3D2007BA5FA /* AppleTVOS */,
-				C3A12E951FE3A3D2007BA5FA /* AppleTVSimulator */,
-				C3A12E991FE3A3D2007BA5FA /* iPhoneOS */,
-				C3A12EA11FE3A3D2007BA5FA /* iPhoneSimulator */,
-				C3A12E9F1FE3A3D2007BA5FA /* MacOSX */,
-				C3A12E9D1FE3A3D2007BA5FA /* WatchOS */,
-				C3A12E971FE3A3D2007BA5FA /* WatchSimulator */,
-			);
-			path = CommonCrypto;
-			sourceTree = "<group>";
-		};
 		C36729151FF4970C005BE1A8 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -399,7 +378,6 @@
 			children = (
 				C3BDFE001FFE6BDB00E060F6 /* SHA3 */,
 				C356173F1FDD765D005316BF /* Argon2 */,
-				C358E7921FE2700600A352D0 /* CommonCrypto */,
 				C31E52E71FE90668004C1F12 /* MD6 */,
 			);
 			path = ModuleMaps;
@@ -414,62 +392,6 @@
 				C36729101FF496D4005BE1A8 /* Crypto.swift */,
 			);
 			path = Core;
-			sourceTree = "<group>";
-		};
-		C3A12E951FE3A3D2007BA5FA /* AppleTVSimulator */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E961FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = AppleTVSimulator;
-			sourceTree = "<group>";
-		};
-		C3A12E971FE3A3D2007BA5FA /* WatchSimulator */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E981FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = WatchSimulator;
-			sourceTree = "<group>";
-		};
-		C3A12E991FE3A3D2007BA5FA /* iPhoneOS */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E9A1FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = iPhoneOS;
-			sourceTree = "<group>";
-		};
-		C3A12E9B1FE3A3D2007BA5FA /* AppleTVOS */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E9C1FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = AppleTVOS;
-			sourceTree = "<group>";
-		};
-		C3A12E9D1FE3A3D2007BA5FA /* WatchOS */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12E9E1FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = WatchOS;
-			sourceTree = "<group>";
-		};
-		C3A12E9F1FE3A3D2007BA5FA /* MacOSX */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12EA01FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = MacOSX;
-			sourceTree = "<group>";
-		};
-		C3A12EA11FE3A3D2007BA5FA /* iPhoneSimulator */ = {
-			isa = PBXGroup;
-			children = (
-				C3A12EA21FE3A3D2007BA5FA /* module.modulemap */,
-			);
-			path = iPhoneSimulator;
 			sourceTree = "<group>";
 		};
 		C3BDFE001FFE6BDB00E060F6 /* SHA3 */ = {

--- a/CatCrypto.xcodeproj/project.pbxproj
+++ b/CatCrypto.xcodeproj/project.pbxproj
@@ -130,6 +130,34 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6097CDD62235D66500D7CEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C35617041FDD74A5005316BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6097CDD12235D30E00D7CEC8;
+			remoteInfo = CommonCryptoModuleMap;
+		};
+		6097CDD82235D66C00D7CEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C35617041FDD74A5005316BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6097CDD12235D30E00D7CEC8;
+			remoteInfo = CommonCryptoModuleMap;
+		};
+		6097CDDA2235D67100D7CEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C35617041FDD74A5005316BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6097CDD12235D30E00D7CEC8;
+			remoteInfo = CommonCryptoModuleMap;
+		};
+		6097CDDC2235D67600D7CEC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C35617041FDD74A5005316BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6097CDD12235D30E00D7CEC8;
+			remoteInfo = CommonCryptoModuleMap;
+		};
 		C328B7981FF4DC4900943D75 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C35617041FDD74A5005316BF /* Project object */;
@@ -533,6 +561,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6097CDD72235D66500D7CEC8 /* PBXTargetDependency */,
 			);
 			name = "CatCrypto-iOS";
 			productName = CatCrypto;
@@ -551,6 +580,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6097CDDB2235D67100D7CEC8 /* PBXTargetDependency */,
 			);
 			name = "CatCrypto-tvOS";
 			productName = "CatCrypto-tvOS";
@@ -569,6 +599,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6097CDDD2235D67600D7CEC8 /* PBXTargetDependency */,
 			);
 			name = "CatCrypto-watchOS";
 			productName = "CatCrypto-watchOS";
@@ -587,6 +618,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6097CDD92235D66C00D7CEC8 /* PBXTargetDependency */,
 			);
 			name = "CatCrypto-macOS";
 			productName = CatCrypto;
@@ -866,6 +898,26 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		6097CDD72235D66500D7CEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */;
+			targetProxy = 6097CDD62235D66500D7CEC8 /* PBXContainerItemProxy */;
+		};
+		6097CDD92235D66C00D7CEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */;
+			targetProxy = 6097CDD82235D66C00D7CEC8 /* PBXContainerItemProxy */;
+		};
+		6097CDDB2235D67100D7CEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */;
+			targetProxy = 6097CDDA2235D67100D7CEC8 /* PBXContainerItemProxy */;
+		};
+		6097CDDD2235D67600D7CEC8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */;
+			targetProxy = 6097CDDC2235D67600D7CEC8 /* PBXContainerItemProxy */;
+		};
 		C328B7991FF4DC4900943D75 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C330B4951FDE93AB005AEECC /* CatCrypto-iOS */;
@@ -879,7 +931,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchos watchsimulator appletvos appletvsimulator";
 			};
 			name = Debug;
 		};
@@ -888,7 +940,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchos watchsimulator appletvos appletvsimulator";
 			};
 			name = Release;
 		};

--- a/CatCrypto.xcodeproj/project.pbxproj
+++ b/CatCrypto.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 48;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 6097CDD42235D30E00D7CEC8 /* Build configuration list for PBXAggregateTarget "CommonCryptoModuleMap" */;
+			buildPhases = (
+				6097CDD52235D32800D7CEC8 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = CommonCryptoModuleMap;
+			productName = CommonCryptoModuleMap;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		92D09986215CC7A8009AF0A6 /* ResultValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D09985215CC7A8009AF0A6 /* ResultValueTests.swift */; };
 		C3077C542010408F00407FDF /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3077C532010408F00407FDF /* ArrayExtension.swift */; };
@@ -589,6 +603,10 @@
 				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = imkcat;
 				TargetAttributes = {
+					6097CDD12235D30E00D7CEC8 = {
+						CreatedOnToolsVersion = 10.2;
+						ProvisioningStyle = Automatic;
+					};
 					C328B7911FF4DC4900943D75 = {
 						CreatedOnToolsVersion = 9.1;
 						LastSwiftMigration = 1000;
@@ -632,6 +650,7 @@
 				C3945E841FE3CBAE009A203D /* CatCrypto-tvOS */,
 				C3945EAC1FE3CE48009A203D /* CatCrypto-watchOS */,
 				C328B7911FF4DC4900943D75 /* CatCrypto-iOSTests */,
+				6097CDD12235D30E00D7CEC8 /* CommonCryptoModuleMap */,
 			);
 		};
 /* End PBXProject section */
@@ -676,6 +695,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		6097CDD52235D32800D7CEC8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "# Based on https://stackoverflow.com/a/42852743/3188334\n\nCOMMON_CRYPTO_DIR=\"${SDKROOT}/usr/include/CommonCrypto\"\n# Xcode 10 ships with a CommonCrypto module map\nif [ -f \"${COMMON_CRYPTO_DIR}/module.modulemap\" ]\nthen\necho \"CommonCrypto already exists, skipping\"\nelse\n# This if-statement means we'll only run the main script if the CommonCryptoModuleMap directory doesn't exist\n# Because otherwise the rest of the script causes a full recompile for anything where CommonCrypto is a dependency\n# Do a \"Clean Build Folder\" to remove this directory and trigger the rest of the script to run\nif [ -d \"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap\" ]; then\necho \"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap directory already exists, so skipping the rest of the script.\"\nexit 0\nfi\n\nmkdir -p \"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap\"\ncat <<EOF > \"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap/module.modulemap\"\nmodule CommonCrypto [system] {\nheader \"${SDKROOT}/usr/include/CommonCrypto/CommonCrypto.h\"\nexport *\n}\nEOF\nfi\n";
+		};
 		C3FD6D3A20037B6D001394CF /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -838,6 +874,24 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		6097CDD22235D30E00D7CEC8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+			};
+			name = Debug;
+		};
+		6097CDD32235D30E00D7CEC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+			};
+			name = Release;
+		};
 		C328B79B1FF4DC4900943D75 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -885,9 +939,7 @@
 				PRODUCT_NAME = CatCrypto;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/iPhoneOS";
-				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/iPhoneSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -916,9 +968,7 @@
 				PRODUCT_NAME = CatCrypto;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/iPhoneOS";
-				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/iPhoneSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1059,9 +1109,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/AppleTVOS";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/AppleTVSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1090,9 +1138,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/AppleTVOS";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/AppleTVSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1121,9 +1167,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/WatchOS";
-				"SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/WatchSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1152,9 +1196,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/WatchOS";
-				"SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]" = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/WatchSimulator";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1185,7 +1227,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/MacOSX";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1214,7 +1256,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${PROJECT_DIR}/Sources/ModuleMaps/CommonCrypto/MacOSX";
+				SWIFT_INCLUDE_PATHS = "${PROJECT_DIR}/Sources/ModuleMaps/Argon2 ${PROJECT_DIR}/Sources/ModuleMaps/MD6 ${PROJECT_DIR}/Sources/ModuleMaps/SHA3 ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap";
 				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1224,6 +1266,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6097CDD42235D30E00D7CEC8 /* Build configuration list for PBXAggregateTarget "CommonCryptoModuleMap" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6097CDD22235D30E00D7CEC8 /* Debug */,
+				6097CDD32235D30E00D7CEC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C328B79A1FF4DC4900943D75 /* Build configuration list for PBXNativeTarget "CatCrypto-iOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Sources/Core/Crypto.swift
+++ b/Sources/Core/Crypto.swift
@@ -20,7 +20,7 @@
 //
 
 import Foundation
-import CommonCryptoFramework
+import CommonCrypto
 
 enum CatCCCryptoErrorCode: Int, EnumDescription {
 

--- a/Sources/Cryptos/MessageDigest.swift
+++ b/Sources/Cryptos/MessageDigest.swift
@@ -20,7 +20,7 @@
 //
 
 import Foundation
-import CommonCryptoFramework
+import CommonCrypto
 import MD6
 
 enum MD6ErrorCode: Int32, EnumDescription {

--- a/Sources/Cryptos/SHA.swift
+++ b/Sources/Cryptos/SHA.swift
@@ -20,7 +20,7 @@
 //
 
 import Foundation
-import CommonCryptoFramework
+import CommonCrypto
 import SHA3
 
 ///  `CatSHA1Crypto` is the crypto for

--- a/Sources/ModuleMaps/CommonCrypto/AppleTVOS/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/AppleTVOS/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/AppleTVSimulator/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/AppleTVSimulator/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/MacOSX/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/MacOSX/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/WatchOS/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/WatchOS/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/WatchSimulator/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/WatchSimulator/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/iPhoneOS/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/iPhoneOS/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}

--- a/Sources/ModuleMaps/CommonCrypto/iPhoneSimulator/module.modulemap
+++ b/Sources/ModuleMaps/CommonCrypto/iPhoneSimulator/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCryptoFramework [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
-    export *
-}


### PR DESCRIPTION
### Added
Added script to dynamically generate `CommonCrypto` module maps if they don't exist.

This is based on https://stackoverflow.com/a/42852743/3188334

Instead of using pre-created module maps, this script will generate them at build time if needed. Since Xcode 10 includes the module maps for `CommonCrypto`, these will not be generated if they already exist. Also, dynamically generating the module maps allows users of the library to build with beta versions of Xcode or on CI providers that may have Xcode in a non-standard location, since paths like the one below are no longer hardcoded:
https://github.com/ImKcat/CatCrypto/blob/4c3e6b389f80c3fb9d873e039b10cb69dbbde34e/Sources/ModuleMaps/CommonCrypto/iPhoneOS/module.modulemap#L2

This was tested on Xcode 10.2 beta and passes Travis CI tests for Xcode 10, but has not been tested on Xcode 9 (where these module maps are not already included in the SDK)
